### PR TITLE
Add ArgoCD App for an app

### DIFF
--- a/manifests/base/an-app-application.yml
+++ b/manifests/base/an-app-application.yml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: an-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/joshbrgs/app-an-app.git
+    targetRevision: HEAD
+    path: manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: an-app
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - base/postgres-storage.yml
   - base/postgres-svc.yml
   - base/postgres.yml
+  - base/an-app-application.yml
 
 


### PR DESCRIPTION
This PR adds an ArgoCD App for an app.
It will deploy the app to the `argocd` namespace.
