### PR TITLE
Add ArgoCD App for example

### DIFF
--- a/manifests/base/example-application.yml
+++ b/manifests/base/example-application.yml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: example
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/joshbrgs/app-example.git
+    targetRevision: HEAD
+    path: manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/base/example-repo.yml
+++ b/manifests/base/example-repo.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+stringData:
+  name: example
+  project: "default"
+  type: "git"
+  url: https://github.com/joshbrgs/app-example.git
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  name: repo-example
+  namespace: argocd
+type: Opaque

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -10,5 +10,7 @@ resources:
   - base/postgres-storage.yml
   - base/postgres-svc.yml
   - base/postgres.yml
+  - base/example-application.yml
+  - base/example-repo.yml
 
 


### PR DESCRIPTION
This PR adds an ArgoCD App for example.
It will deploy the app to the `argocd` namespace.
